### PR TITLE
ShellPkg/AcpiView: Fix field validator invocation

### DIFF
--- a/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/OnigurumaUefiPort.c
@@ -93,6 +93,6 @@ void* memcpy (void *dest, const void *src, unsigned int count)
 
 void* memset (void *dest, char ch, unsigned int count)
 {
-  return SetMem (dest, ch, count);
+  return SetMem (dest, count, ch);
 }
 

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.c
@@ -1,7 +1,7 @@
 /** @file
   ACPI parser
 
-  Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.
+  Copyright (c) 2016 - 2020, Arm Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -596,13 +596,12 @@ ParseAcpi (
               Parser[Index].Length
               );
         } // switch
-
-        // Validating only makes sense if we are tracing
-        // the parsed table entries, to report by table name.
-        if (GetConsistencyChecking () &&
-            (Parser[Index].FieldValidator != NULL)) {
-          Parser[Index].FieldValidator (Ptr, Parser[Index].Context);
-        }
+      }
+      // Validating only makes sense if we are tracing
+      // the parsed table entries, to report by table name.
+      if (GetConsistencyChecking () &&
+          (Parser[Index].FieldValidator != NULL)) {
+        Parser[Index].FieldValidator (Ptr, Parser[Index].Context);
       }
       Print (L"\n");
     } // if (Trace)

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for ACPI parser
 
-  Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.
+  Copyright (c) 2016 - 2020, Arm Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -664,6 +664,28 @@ ParseAcpiMadt (
 VOID
 EFIAPI
 ParseAcpiMcfg (
+  IN BOOLEAN Trace,
+  IN UINT8*  Ptr,
+  IN UINT32  AcpiTableLength,
+  IN UINT8   AcpiTableRevision
+  );
+
+/**
+  This function parses the ACPI PCCT table including its sub-structures
+  of type 0 through 4.
+  When trace is enabled this function parses the PCCT table and
+  traces the ACPI table fields.
+
+  This function also performs validation of the ACPI table fields.
+
+  @param [in] Trace              If TRUE, trace the ACPI fields.
+  @param [in] Ptr                Pointer to the start of the buffer.
+  @param [in] AcpiTableLength    Length of the ACPI table.
+  @param [in] AcpiTableRevision  Revision of the ACPI table.
+**/
+VOID
+EFIAPI
+ParseAcpiPcct (
   IN BOOLEAN Trace,
   IN UINT8*  Ptr,
   IN UINT32  AcpiTableLength,

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiTableParser.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiTableParser.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for ACPI table parser
 
-  Copyright (c) 2016 - 2018, ARM Limited. All rights reserved.
+  Copyright (c) 2016 - 2020, Arm Limited. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -11,7 +11,7 @@
 /**
   The maximum number of ACPI table parsers.
 */
-#define MAX_ACPI_TABLE_PARSERS          16
+#define MAX_ACPI_TABLE_PARSERS          32
 
 /** An invalid/NULL signature value.
 */

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Pcct/PcctParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Pcct/PcctParser.c
@@ -1,0 +1,615 @@
+/** @file
+  PCCT table parser
+
+  Copyright (c) 2020, Arm Limited.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+    - ACPI 6.3 Specification - January 2019
+**/
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiLib.h>
+#include "AcpiParser.h"
+#include "AcpiView.h"
+#include "AcpiViewConfig.h"
+#include "PcctParser.h"
+
+// Local variables
+STATIC ACPI_DESCRIPTION_HEADER_INFO AcpiHdrInfo;
+
+STATIC UINT32* PccGlobalFlags;
+STATIC UINT8*  PccSubspaceLength;
+STATIC UINT8*  PccSubspaceType;
+STATIC UINT8*  ExtendedPccSubspaceInterruptFlags;
+
+/**
+  This function validates the length coded on 4 bytes of a shared memory range
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateRangeLength4 (
+  IN UINT8* Ptr,
+  IN VOID*  Context
+  )
+{
+  if (*(UINT32*)Ptr < MIN_EXT_PCC_SUBSPACE_MEM_RANGE_LEN) {
+    IncrementErrorCount ();
+    Print (
+      L"\nError: Shared memory range length is too short.\n"
+      L"Length is %u when it should be greater than or equal to %u",
+      *(UINT32*)Ptr,
+      MIN_EXT_PCC_SUBSPACE_MEM_RANGE_LEN
+      );
+  }
+}
+
+/**
+  This function validates the length coded on 8 bytes of a shared memory range
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateRangeLength8 (
+  IN UINT8* Ptr,
+  IN VOID*  Context
+  )
+{
+  if (*(UINT64*)Ptr <= MIN_MEMORY_RANGE_LENGTH) {
+    IncrementErrorCount ();
+    Print (
+      L"\nError: Shared memory range length is too short.\n"
+      L"Length is %u when it should be greater than %u",
+      *(UINT64*)Ptr,
+      MIN_MEMORY_RANGE_LENGTH
+      );
+  }
+}
+
+/**
+  This function validates address space for type 0 structure.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidatePccType0Gas (
+  IN UINT8* Ptr,
+  IN VOID*  Context
+  )
+{
+  switch (*(UINT8*)Ptr) {
+#if !(defined (MDE_CPU_ARM) || defined (MDE_CPU_AARCH64))
+    case EFI_ACPI_6_3_SYSTEM_IO:
+#endif //if not (defined (MDE_CPU_ARM) || defined (MDE_CPU_AARCH64))
+    case EFI_ACPI_6_3_SYSTEM_MEMORY:
+      return;
+    default:
+      IncrementErrorCount ();
+      Print (L"\nError: Invalid address space");
+  }
+}
+
+/**
+  This function validates address space for structures of types other than 0.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidatePccGas (
+  IN UINT8* Ptr,
+  IN VOID*  Context
+  )
+{
+  switch (*(UINT8*)Ptr) {
+#if !(defined (MDE_CPU_ARM) || defined (MDE_CPU_AARCH64))
+    case EFI_ACPI_6_3_SYSTEM_IO:
+#endif //if not (defined (MDE_CPU_ARM) || defined (MDE_CPU_AARCH64))
+    case EFI_ACPI_6_3_FUNCTIONAL_FIXED_HARDWARE:
+    case EFI_ACPI_6_3_SYSTEM_MEMORY:
+      return;
+    default:
+      IncrementErrorCount ();
+      Print (L"\nError: Invalid address space");
+  }
+}
+
+/**
+  This function validates doorbell address space for type 4 structure.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidatePccDoorbellGas (
+  IN UINT8* Ptr,
+  IN VOID*  Context
+  )
+{
+  // For slave subspaces this field is optional, if not present the field
+  // should just contain zeros.
+  if (*PccSubspaceType == EFI_ACPI_6_3_PCCT_SUBSPACE_TYPE_4_EXTENDED_PCC) {
+    if (IsZeroBuffer (
+          Ptr,
+          sizeof (EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE)
+          )) {
+      return;
+    }
+  }
+
+  ValidatePccGas (Ptr, Context);
+}
+
+/**
+  This function validates interrupt acknowledge address space for
+  type 4 structure.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidatePccIntAckGas (
+  IN UINT8* Ptr,
+  IN VOID*  Context
+  )
+{
+  // If the subspace does not support interrupts or the interrupt is
+  // edge driven the register may be omitted. A value of 0x0 on all
+  // 12 bytes of the GAS structure indicates the register is not
+  // present.
+  if (((*PccGlobalFlags & EFI_ACPI_6_3_PCCT_FLAGS_PLATFORM_INTERRUPT) !=
+       EFI_ACPI_6_3_PCCT_FLAGS_PLATFORM_INTERRUPT) ||
+      ((*ExtendedPccSubspaceInterruptFlags &
+       EFI_ACPI_6_3_PCCT_SUBSPACE_PLATFORM_INTERRUPT_FLAGS_MODE) ==
+       EFI_ACPI_6_3_PCCT_SUBSPACE_PLATFORM_INTERRUPT_FLAGS_MODE)) {
+    if (IsZeroBuffer (
+          Ptr,
+          sizeof (EFI_ACPI_6_3_GENERIC_ADDRESS_STRUCTURE)
+          )) {
+      return;
+    }
+  }
+
+  ValidatePccGas (Ptr, Context);
+}
+
+/**
+  This function validates error status address space for type 4 structure.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidatePccErrStatusGas (
+  IN UINT8* Ptr,
+  IN VOID*  Context
+  )
+{
+  // This field is ignored by the OSPM on slave channels.
+  if (*PccSubspaceType == EFI_ACPI_6_3_PCCT_SUBSPACE_TYPE_4_EXTENDED_PCC) {
+    return;
+  }
+
+  ValidatePccGas (Ptr, Context);
+}
+
+/**
+  This function validates platform interrupt flags for type 4 structure.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidatePlatInterrupt (
+  IN UINT8* Ptr,
+  IN VOID*  Context
+  )
+{
+  // If a slave subspace is present in the PCCT, then the global Platform
+  // Interrupt flag must be set to 1.
+  if ((*PccSubspaceType == EFI_ACPI_6_3_PCCT_SUBSPACE_TYPE_4_EXTENDED_PCC) &&
+      ((*PccGlobalFlags & EFI_ACPI_6_3_PCCT_FLAGS_PLATFORM_INTERRUPT) !=
+        EFI_ACPI_6_3_PCCT_FLAGS_PLATFORM_INTERRUPT)) {
+    IncrementErrorCount ();
+    Print (
+      L"\nError: Global Platform interrupt flag must be set to 1" \
+        L" if a PCC type 4 structure is present in PCCT."
+      );
+  }
+}
+
+/**
+  An ACPI_PARSER array describing the ACPI PCCT Table.
+*/
+STATIC CONST ACPI_PARSER PcctParser[] = {
+  PARSE_ACPI_HEADER (&AcpiHdrInfo),
+  {L"Flags", 4, 36, NULL, NULL, (VOID**)&PccGlobalFlags, NULL, NULL},
+  {L"Reserved", 8, 40, NULL, NULL, NULL, NULL, NULL}
+};
+
+/**
+  An ACPI_PARSER array describing the platform communications channel subspace
+  structure header.
+*/
+STATIC CONST ACPI_PARSER PccSubspaceHeaderParser[] = {
+  PCC_SUBSPACE_HEADER ()
+  // ... Type Specific Fields ...
+};
+
+/**
+  An ACPI_PARSER array describing the Generic Communications Subspace - Type 0
+*/
+STATIC CONST ACPI_PARSER PccSubspaceType0Parser[] = {
+  PCC_SUBSPACE_HEADER (),
+  {L"Reserved", 6, 2, L"%x %x %x %x %x %x", Dump6Chars, NULL, NULL, NULL},
+  {L"Base Address", 8, 8, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Memory Range Length", 8, 16, L"0x%lx", NULL, NULL, ValidateRangeLength8,
+    NULL},
+  {L"Doorbell Register", 12, 24, NULL, DumpGas, NULL, ValidatePccType0Gas,
+    NULL},
+  {L"Doorbell Preserve", 8, 36, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Doorbell Write", 8, 44, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Nominal Latency", 4, 52, L"%u", NULL, NULL, NULL, NULL},
+  {L"Maximum Periodic Access Rate", 4, 56, L"%u", NULL, NULL, NULL, NULL},
+  {L"Minimum Request Turnaround Time", 2, 60, L"%u", NULL, NULL, NULL, NULL}
+};
+
+/**
+  An ACPI_PARSER array describing the HW-Reduced Communications Subspace
+  - Type 1
+*/
+STATIC CONST ACPI_PARSER PccSubspaceType1Parser[] = {
+  PCC_SUBSPACE_HEADER (),
+  {L"Platform Interrupt", 4, 2, L"0x%x", NULL, NULL, NULL, NULL},
+  {L"Platform Interrupt Flags", 1, 6, L"0x%x", NULL, NULL, NULL, NULL},
+  {L"Reserved", 1, 7, L"0x%x", NULL, NULL, NULL, NULL},
+  {L"Base Address", 8, 8, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Memory Range Length", 8, 16, L"0x%lx", NULL, NULL, ValidateRangeLength8,
+    NULL},
+  {L"Doorbell Register", 12, 24, NULL, DumpGas, NULL,
+    ValidatePccGas, NULL},
+  {L"Doorbell Preserve", 8, 36, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Doorbell Write", 8, 44, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Nominal Latency", 4, 52, L"%u", NULL, NULL, NULL, NULL},
+  {L"Maximum Periodic Access Rate", 4, 56, L"%u", NULL, NULL, NULL, NULL},
+  {L"Minimum Request Turnaround Time", 2, 60, L"%u", NULL, NULL, NULL, NULL}
+};
+
+/**
+  An ACPI_PARSER array describing the HW-Reduced Communications Subspace
+  - Type 2
+*/
+STATIC CONST ACPI_PARSER PccSubspaceType2Parser[] = {
+  PCC_SUBSPACE_HEADER (),
+  {L"Platform Interrupt", 4, 2, L"0x%x", NULL, NULL, NULL, NULL},
+  {L"Platform Interrupt Flags", 1, 6, L"0x%x", NULL, NULL, NULL, NULL},
+  {L"Reserved", 1, 7, L"0x%x", NULL, NULL, NULL, NULL},
+  {L"Base Address", 8, 8, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Memory Range Length", 8, 16, L"0x%lx", NULL, NULL, ValidateRangeLength8,
+    NULL},
+  {L"Doorbell Register", 12, 24, NULL, DumpGas, NULL,
+    ValidatePccGas, NULL},
+  {L"Doorbell Preserve", 8, 36, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Doorbell Write", 8, 44, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Nominal Latency", 4, 52, L"%u", NULL, NULL, NULL, NULL},
+  {L"Maximum Periodic Access Rate", 4, 56, L"%u", NULL, NULL, NULL, NULL},
+  {L"Minimum Request Turnaround Time", 2, 60, L"%u", NULL, NULL, NULL, NULL},
+  {L"Platform Interrupt Ack Register", 12, 62, NULL, DumpGas, NULL,
+    ValidatePccGas, NULL},
+  {L"Platform Interrupt Ack Preserve", 8, 74, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Platform Interrupt Ack Write", 8, 82, L"0x%lx", NULL, NULL,
+    NULL, NULL},
+};
+
+/**
+  An ACPI_PARSER array describing the Extended PCC Subspaces - Type 3/4
+*/
+STATIC CONST ACPI_PARSER PccSubspaceType3Parser[] = {
+  PCC_SUBSPACE_HEADER (),
+  {L"Platform Interrupt", 4, 2, L"0x%x", NULL, NULL,
+    ValidatePlatInterrupt, NULL},
+  {L"Platform Interrupt Flags", 1, 6, L"0x%x", NULL,
+    (VOID**)&ExtendedPccSubspaceInterruptFlags, NULL, NULL},
+  {L"Reserved", 1, 7, L"0x%x", NULL, NULL, NULL, NULL},
+  {L"Base Address", 8, 8, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Memory Range Length", 4, 16, L"0x%x", NULL, NULL, ValidateRangeLength4,
+    NULL},
+  {L"Doorbell Register", 12, 20, NULL, DumpGas, NULL,
+    ValidatePccDoorbellGas, NULL},
+  {L"Doorbell Preserve", 8, 32, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Doorbell Write", 8, 40, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Nominal Latency", 4, 48, L"%u", NULL, NULL, NULL, NULL},
+  {L"Maximum Periodic Access Rate", 4, 52, L"%u", NULL, NULL, NULL, NULL},
+  {L"Minimum Request Turnaround Time", 4, 56, L"%u", NULL, NULL, NULL, NULL},
+  {L"Platform Interrupt Ack Register", 12, 60, NULL, DumpGas, NULL,
+    ValidatePccIntAckGas, NULL},
+  {L"Platform Interrupt Ack Preserve", 8, 72, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Platform Interrupt Ack Set", 8, 80, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Reserved", 8, 88, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Cmd Complete Check Reg Addr", 12, 96, NULL, DumpGas, NULL,
+    ValidatePccGas, NULL},
+  {L"Cmd Complete Check Mask", 8, 108, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Cmd Update Reg Addr", 12, 116, NULL, DumpGas, NULL,
+    ValidatePccGas, NULL},
+  {L"Cmd Update Preserve mask", 8, 128, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Cmd Update Set mask", 8, 136, L"0x%lx", NULL, NULL, NULL, NULL},
+  {L"Error Status Register", 12, 144, NULL, DumpGas, NULL,
+    ValidatePccErrStatusGas, NULL},
+  {L"Error Status Mask", 8, 156, L"0x%lx", NULL, NULL, NULL, NULL},
+};
+
+/**
+  This function parses the PCC Subspace type 0.
+
+  @param [in] Ptr     Pointer to the start of Subspace Structure.
+  @param [in] Length  Length of the Subspace Structure.
+**/
+STATIC
+VOID
+DumpPccSubspaceType0 (
+  IN UINT8* Ptr,
+  IN UINT8  Length
+  )
+{
+  ParseAcpi (
+    TRUE,
+    2,
+    "Subspace Type 0",
+    Ptr,
+    Length,
+    PARSER_PARAMS (PccSubspaceType0Parser)
+    );
+}
+
+/**
+  This function parses the PCC Subspace type 1.
+
+  @param [in] Ptr     Pointer to the start of the Subspace Structure.
+  @param [in] Length  Length of the Subspace Structure.
+**/
+STATIC
+VOID
+DumpPccSubspaceType1 (
+  IN UINT8* Ptr,
+  IN UINT8  Length
+  )
+{
+  ParseAcpi (
+    TRUE,
+    2,
+    "Subspace Type 1",
+    Ptr,
+    Length,
+    PARSER_PARAMS (PccSubspaceType1Parser)
+    );
+}
+
+/**
+  This function parses the PCC Subspace type 2.
+
+  @param [in] Ptr     Pointer to the start of the Subspace Structure.
+  @param [in] Length  Length of the Subspace Structure.
+**/
+STATIC
+VOID
+DumpPccSubspaceType2 (
+  IN UINT8* Ptr,
+  IN UINT8  Length
+  )
+{
+  ParseAcpi (
+    TRUE,
+    2,
+    "Subspace Type 2",
+    Ptr,
+    Length,
+    PARSER_PARAMS (PccSubspaceType2Parser)
+    );
+}
+
+/**
+  This function parses the PCC Subspace type 3.
+
+  @param [in] Ptr     Pointer to the start of the Subspace Structure.
+  @param [in] Length  Length of the Subspace Structure.
+**/
+STATIC
+VOID
+DumpPccSubspaceType3 (
+  IN UINT8* Ptr,
+  IN UINT8  Length
+  )
+{
+  ParseAcpi (
+    TRUE,
+    2,
+    "Subspace Type 3",
+    Ptr,
+    Length,
+    PARSER_PARAMS (PccSubspaceType3Parser)
+    );
+}
+
+/**
+  This function parses the PCC Subspace type 4.
+
+  @param [in] Ptr     Pointer to the start of the Subspace Structure.
+  @param [in] Length  Length of the Subspace Structure.
+**/
+STATIC
+VOID
+DumpPccSubspaceType4 (
+  IN UINT8* Ptr,
+  IN UINT8  Length
+  )
+{
+  ParseAcpi (
+    TRUE,
+    2,
+    "Subspace Type 4",
+    Ptr,
+    Length,
+    PARSER_PARAMS (PccSubspaceType3Parser)
+    );
+}
+
+/**
+  This function parses the ACPI PCCT table including its sub-structures
+  of type 0 through 4.
+  When trace is enabled this function parses the PCCT table and
+  traces the ACPI table fields.
+
+  This function also performs validation of the ACPI table fields.
+
+  @param [in] Trace              If TRUE, trace the ACPI fields.
+  @param [in] Ptr                Pointer to the start of the buffer.
+  @param [in] AcpiTableLength    Length of the ACPI table.
+  @param [in] AcpiTableRevision  Revision of the ACPI table.
+**/
+VOID
+EFIAPI
+ParseAcpiPcct (
+  IN BOOLEAN Trace,
+  IN UINT8*  Ptr,
+  IN UINT32  AcpiTableLength,
+  IN UINT8   AcpiTableRevision
+  )
+{
+  UINT32 Offset;
+  UINT8* PccSubspacePtr;
+  UINTN  SubspaceCount;
+
+  if (!Trace) {
+    return;
+  }
+
+  Offset = ParseAcpi (
+             TRUE,
+             0,
+             "PCCT",
+             Ptr,
+             AcpiTableLength,
+             PARSER_PARAMS (PcctParser)
+             );
+
+  PccSubspacePtr = Ptr + Offset;
+
+  SubspaceCount = 0;
+  while (Offset < AcpiTableLength) {
+    // Parse common structure header to obtain Type and Length.
+    ParseAcpi (
+      FALSE,
+      0,
+      NULL,
+      PccSubspacePtr,
+      AcpiTableLength - Offset,
+      PARSER_PARAMS (PccSubspaceHeaderParser)
+      );
+
+    // Check if the values used to control the parsing logic have been
+    // successfully read.
+    if ((PccSubspaceType == NULL) ||
+        (PccSubspaceLength == NULL)) {
+      IncrementErrorCount ();
+      Print (
+        L"ERROR: Insufficient remaining table buffer length to read the " \
+          L"structure header. Length = %u.\n",
+        AcpiTableLength - Offset
+        );
+      return;
+    }
+
+    // Validate Structure length
+    if ((*PccSubspaceLength == 0) ||
+        ((Offset + (*PccSubspaceLength)) > AcpiTableLength)) {
+      IncrementErrorCount ();
+      Print (
+        L"ERROR: Invalid Structure length. " \
+          L"Length = %u. Offset = %u. AcpiTableLength = %u.\n",
+        *PccSubspaceLength,
+        Offset,
+        AcpiTableLength
+        );
+      return;
+    }
+
+    switch (*PccSubspaceType) {
+      case EFI_ACPI_6_3_PCCT_SUBSPACE_TYPE_GENERIC:
+        DumpPccSubspaceType0 (
+          PccSubspacePtr,
+          *PccSubspaceLength
+          );
+        break;
+      case EFI_ACPI_6_3_PCCT_SUBSPACE_TYPE_1_HW_REDUCED_COMMUNICATIONS:
+        DumpPccSubspaceType1 (
+          PccSubspacePtr,
+          *PccSubspaceLength
+          );
+        break;
+      case EFI_ACPI_6_3_PCCT_SUBSPACE_TYPE_2_HW_REDUCED_COMMUNICATIONS:
+        DumpPccSubspaceType2 (
+          PccSubspacePtr,
+          *PccSubspaceLength
+          );
+        break;
+      case EFI_ACPI_6_3_PCCT_SUBSPACE_TYPE_3_EXTENDED_PCC:
+        DumpPccSubspaceType3 (
+          PccSubspacePtr,
+          *PccSubspaceLength
+          );
+        break;
+      case EFI_ACPI_6_3_PCCT_SUBSPACE_TYPE_4_EXTENDED_PCC:
+        DumpPccSubspaceType4 (
+          PccSubspacePtr,
+          *PccSubspaceLength
+          );
+        break;
+      default:
+        IncrementErrorCount ();
+        Print (
+          L"ERROR: Unknown PCC subspace structure:"
+            L" Type = %u, Length = %u\n",
+          PccSubspaceType,
+          *PccSubspaceLength
+          );
+    }
+
+    PccSubspacePtr += *PccSubspaceLength;
+    Offset += *PccSubspaceLength;
+    SubspaceCount++;
+  } // while
+
+  if (SubspaceCount > MAX_PCC_SUBSPACES) {
+    IncrementErrorCount ();
+    Print (L"ERROR: Too many PCC subspaces.");
+  }
+}

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Pcct/PcctParser.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Pcct/PcctParser.h
@@ -1,0 +1,33 @@
+/** @file
+  Header file for PCCT parser
+
+  Copyright (c) 2020, Arm Limited.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef PCCT_PARSER_H_
+#define PCCT_PARSER_H_
+
+/**
+  Minimum value for the 'length' field in subspaces of types 0, 1 and 2.
+*/
+#define MIN_MEMORY_RANGE_LENGTH                 8
+
+/**
+  Minimum value for the 'length' field in subspaces of types 3 and 4.
+*/
+#define MIN_EXT_PCC_SUBSPACE_MEM_RANGE_LEN      16
+
+/**
+  Maximum number of PCC subspaces.
+*/
+#define MAX_PCC_SUBSPACES                       256
+
+/**
+  Parser for the header of any type of PCC subspace.
+*/
+#define PCC_SUBSPACE_HEADER()                                             \
+  {L"Type", 1, 0, L"0x%x", NULL, (VOID**)&PccSubspaceType, NULL, NULL},   \
+  {L"Length", 1, 1, L"%u", NULL, (VOID**)&PccSubspaceLength, NULL, NULL}
+
+#endif // PCCT_PARSER_H_

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.c
@@ -1,7 +1,7 @@
 /** @file
   Main file for 'acpiview' Shell command function.
 
-  Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.<BR>
+  Copyright (c) 2016 - 2020, Arm Limited. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -57,6 +57,8 @@ ACPI_TABLE_PARSER ParserList[] = {
   {EFI_ACPI_6_2_MULTIPLE_APIC_DESCRIPTION_TABLE_SIGNATURE, ParseAcpiMadt},
   {EFI_ACPI_6_2_PCI_EXPRESS_MEMORY_MAPPED_CONFIGURATION_SPACE_BASE_ADDRESS_DESCRIPTION_TABLE_SIGNATURE,
    ParseAcpiMcfg},
+  {EFI_ACPI_6_2_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE,
+   ParseAcpiPcct},
   {EFI_ACPI_6_2_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_STRUCTURE_SIGNATURE,
    ParseAcpiPptt},
   {RSDP_TABLE_INFO, ParseAcpiRsdp},

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/UefiShellAcpiViewCommandLib.inf
@@ -1,7 +1,7 @@
 ##  @file
 # Provides Shell 'acpiview' command functions
 #
-# Copyright (c) 2016 - 2020, ARM Limited. All rights reserved.<BR>
+# Copyright (c) 2016 - 2020, Arm Limited. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -37,6 +37,8 @@
   Parsers/Madt/MadtParser.c
   Parsers/Madt/MadtParser.h
   Parsers/Mcfg/McfgParser.c
+  Parsers/Pcct/PcctParser.c
+  Parsers/Pcct/PcctParser.h
   Parsers/Pptt/PpttParser.c
   Parsers/Pptt/PpttParser.h
   Parsers/Rsdp/RsdpParser.c

--- a/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
+++ b/UefiCpuPkg/Library/RegisterCpuFeaturesLib/CpuFeaturesInitialize.c
@@ -126,8 +126,9 @@ CpuInitDataInitialize (
 
   GetNumberOfProcessor (&NumberOfCpus, &NumberOfEnabledProcessors);
 
-  CpuFeaturesData->InitOrder = AllocateZeroPool (sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus);
+  CpuFeaturesData->InitOrder = AllocatePages (EFI_SIZE_TO_PAGES (sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus));
   ASSERT (CpuFeaturesData->InitOrder != NULL);
+  ZeroMem (CpuFeaturesData->InitOrder, sizeof (CPU_FEATURES_INIT_ORDER) * NumberOfCpus);
 
   //
   // Collect CPU Features information


### PR DESCRIPTION
Bugzilla: 3046 (https://bugzilla.tianocore.org/show_bug.cgi?id=3046)

The field validator function provides means to validate fields
in the ACPI table structures. To print complex field types a
print formatter function is provided.

The field validator was being invoked for simple data fields
for which the default print format is used. However, the field
validator function was not invoked if a print formatter function
was provided.

This problem is noticed when a Generic Address Structure (GAS)
is printed using DumpGas() and a field validator is present
to validate the GAS structure.

To fix this move the invocation of the field validator after
the field is printed such that the validation function is
called even when a print formatter function is present.

Signed-off-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Zhichao Gao <zhichao.gao@intel.com>